### PR TITLE
Issue with Gunicorn timeout fixed using an environment variable

### DIFF
--- a/WEB_Game/compose.yaml
+++ b/WEB_Game/compose.yaml
@@ -7,6 +7,7 @@ services:
     restart: always
     environment:
       - sec_key=tctc_key
+      - gunicorn_timeout=250
     networks:
       - tctctoe-net
 

--- a/WEB_Game/server/Dockerfile
+++ b/WEB_Game/server/Dockerfile
@@ -5,8 +5,13 @@ COPY . /api
 WORKDIR /api
 
 RUN pip3 install -r requirements.txt && apt-get update && \
-apt-get install curl vim -y
+apt-get install curl vim -y && pip3 install gunicorn
+
+ENV gunicorn_timeout=200
 
 EXPOSE 8080
+ 
+#CMD ["sh", "-c", "gunicorn", "-w 1", "-b", "0.0.0.0:8080", "api:tctctoe_server", "--timeout", "$gunicorn_timeout", "--log-level", "debug"]
+RUN chmod +x start-api.sh
 
-CMD ["gunicorn", "-w 1", "-b", "0.0.0.0:8080", "api:tctctoe_server"]
+ENTRYPOINT [ "/bin/bash", "-c", "./start-api.sh" ]   

--- a/WEB_Game/server/requirements.txt
+++ b/WEB_Game/server/requirements.txt
@@ -1,3 +1,2 @@
 flask
 flask_cors
-gunicorn

--- a/WEB_Game/server/start-api.sh
+++ b/WEB_Game/server/start-api.sh
@@ -1,0 +1,10 @@
+#/bin/bash
+
+
+function run(){
+    echo "Starting Gunicorn server on 0.0.0.0:8080"
+    echo "Gunicorn Timeout: ${gunicorn_timeout}"
+    gunicorn -w 1 -b 0.0.0.0:8080 api:tctctoe_server --timeout ${gunicorn_timeout} --log-level debug
+}
+
+run


### PR DESCRIPTION
The environment variable called `gunicorn_timeout`controls the gunicorn timeout. Also, now the gunicorn server is started using a Bash script called `start-api.sh`.